### PR TITLE
Ensure API returns consistent field names

### DIFF
--- a/backend/models/models.go
+++ b/backend/models/models.go
@@ -8,25 +8,29 @@ import (
 
 // Request는 HTTP 요청 데이터를 저장하는 모델입니다.
 type Request struct {
-	gorm.Model
+	ID          uint            `json:"id" gorm:"primaryKey"`
 	Method      string          `json:"method"`
 	Path        string          `json:"path"`
 	Headers     string          `json:"headers"`
 	Body        string          `json:"body"`
 	IP          string          `json:"ip"`
 	CreatedAt   time.Time       `json:"created_at"`
+	UpdatedAt   time.Time       `json:"updated_at"`
+	DeletedAt   gorm.DeletedAt  `json:"deleted_at" gorm:"index"`
 	TCPRequests []TCPConnection `json:"tcp_requests" gorm:"foreignKey:RequestID"`
 }
 
 // TCPConnection은 외부 TCP 서버와의 통신 정보를 저장하는 모델입니다.
 type TCPConnection struct {
-	gorm.Model
-	RequestID    uint      `json:"request_id"`
-	ServerName   string    `json:"server_name"`
-	ServerAddr   string    `json:"server_addr"`
-	SentData     string    `json:"sent_data"`
-	ReceivedData string    `json:"received_data"`
-	Success      bool      `json:"success"`
-	Error        string    `json:"error"`
-	CreatedAt    time.Time `json:"created_at"`
+	ID           uint           `json:"id" gorm:"primaryKey"`
+	RequestID    uint           `json:"request_id"`
+	ServerName   string         `json:"server_name"`
+	ServerAddr   string         `json:"server_addr"`
+	SentData     string         `json:"sent_data"`
+	ReceivedData string         `json:"received_data"`
+	Success      bool           `json:"success"`
+	Error        string         `json:"error"`
+	CreatedAt    time.Time      `json:"created_at"`
+	UpdatedAt    time.Time      `json:"updated_at"`
+	DeletedAt    gorm.DeletedAt `json:"deleted_at" gorm:"index"`
 }

--- a/backend/models/tcp_server.go
+++ b/backend/models/tcp_server.go
@@ -1,15 +1,20 @@
 package models
 
 import (
+	"time"
+
 	"gorm.io/gorm"
 )
 
 // TCPServer는 TCP 서버 연결 정보를 저장하는 모델입니다.
 type TCPServer struct {
-	gorm.Model
-	Name string `json:"name" gorm:"uniqueIndex"`
-	Host string `json:"host"`
-	Port int    `json:"port"`
+	ID        uint           `json:"id" gorm:"primaryKey"`
+	Name      string         `json:"name" gorm:"uniqueIndex"`
+	Host      string         `json:"host"`
+	Port      int            `json:"port"`
+	CreatedAt time.Time      `json:"created_at"`
+	UpdatedAt time.Time      `json:"updated_at"`
+	DeletedAt gorm.DeletedAt `json:"deleted_at" gorm:"index"`
 }
 
 // TCPServerRequest는 TCP 서버 생성/수정 요청 구조체입니다.


### PR DESCRIPTION
## Summary
- add explicit `id` and timestamp JSON tags to Request, TCPConnection, and TCPServer models so API responses use predictable field names
- prevent out-of-bounds DataView access in PacketDataTab by validating chain lengths and truncating overlong string inputs

## Testing
- `go test ./...` *(no output; command terminated after waiting)*
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68930e5685448330b3c5a3242dd266f1