### PR TITLE
Add local TCP process kill feature

### DIFF
--- a/backend/handlers/tcp_status_handlers.go
+++ b/backend/handlers/tcp_status_handlers.go
@@ -1,9 +1,12 @@
 package handlers
 
 import (
+	"fmt"
 	"net"
 	"net/http"
+	"os/exec"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -89,4 +92,43 @@ func (h *TCPServerHandler) GetTCPLogs(c *gin.Context) {
 	// 실제 환경에서는 여기서 해당 TCP 서버에 대한 로그 목록을 조회
 	// 이 예제에서는 빈 배열 반환
 	c.JSON(http.StatusOK, []gin.H{})
+}
+
+// KillTCPServer는 활성화된 로컬 TCP 서버 프로세스를 강제 종료합니다.
+func (h *TCPServerHandler) KillTCPServer(c *gin.Context) {
+	server, ok := h.getServerByID(c)
+	if !ok {
+		return
+	}
+
+	if server.Host != "127.0.0.1" && server.Host != "localhost" {
+		c.JSON(http.StatusForbidden, gin.H{"error": "로컬 서버만 종료할 수 있습니다"})
+		return
+	}
+
+	addr := net.JoinHostPort(server.Host, strconv.Itoa(server.Port))
+	conn, err := net.DialTimeout("tcp", addr, 3*time.Second)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "포트가 활성화되어 있지 않습니다"})
+		return
+	}
+	conn.Close()
+
+	cmd := exec.Command("sh", "-c", fmt.Sprintf("lsof -ti:%d", server.Port))
+	output, err := cmd.Output()
+	if err != nil || len(output) == 0 {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "프로세스 ID를 찾을 수 없습니다"})
+		return
+	}
+
+	for _, pid := range strings.Fields(string(output)) {
+		_ = exec.Command("kill", "-9", pid).Run()
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"id":      server.ID,
+		"name":    server.Name,
+		"message": "프로세스 종료됨",
+		"status":  "Dead",
+	})
 }

--- a/backend/routes/routes.go
+++ b/backend/routes/routes.go
@@ -46,6 +46,7 @@ func SetupRoutes(r *gin.Engine, db *gorm.DB) {
 			tc.GET("/:id/status", tcpServerHandler.CheckTCPStatus)   // TCP 서버 상태 확인
 			tc.POST("/:id/start", tcpServerHandler.StartTCPServer)   // TCP 서버 시작
 			tc.POST("/:id/stop", tcpServerHandler.StopTCPServer)     // TCP 서버 중지
+			tc.POST("/:id/kill", tcpServerHandler.KillTCPServer)     // TCP 서버 프로세스 종료
 			tc.GET("/:id/requests", tcpServerHandler.GetTCPRequests) // TCP 서버 요청 목록
 			tc.GET("/:id/logs", tcpServerHandler.GetTCPLogs)         // TCP 서버 로그 목록
 

--- a/frontend/src/api/tcpApi.js
+++ b/frontend/src/api/tcpApi.js
@@ -67,6 +67,13 @@ export async function stopTCPServer(id) {
   });
 }
 
+// TCP 서버 프로세스 강제 종료
+export async function killTCPServer(id) {
+  return await fetchWithErrorHandling(`${API_BASE_URL}/tcp/${id}/kill`, {
+    method: 'POST',
+  });
+}
+
 // TCP 요청 내역 조회
 export async function fetchTCPRequests(tcpId) {
   return await fetchWithErrorHandling(`${API_BASE_URL}/tcp/${tcpId}/requests`);

--- a/frontend/src/components/TCPActionButtons.jsx
+++ b/frontend/src/components/TCPActionButtons.jsx
@@ -5,10 +5,11 @@ import {
   Settings as SettingsIcon,
   Delete as DeleteIcon,
   PlayCircle as PlayCircleIcon,
-  StopCircle as StopCircleIcon
+  StopCircle as StopCircleIcon,
+  PowerSettingsNew as PowerSettingsNewIcon
 } from '@mui/icons-material';
 
-const TCPActionButtons = ({ currentTCP, onAdd, onEdit, onDelete, onStart, onStop }) => (
+const TCPActionButtons = ({ currentTCP, onAdd, onEdit, onDelete, onStart, onStop, onKill }) => (
   <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 2 }}>
     <Box>
       <Tooltip title="TCP 서버 추가">
@@ -60,6 +61,21 @@ const TCPActionButtons = ({ currentTCP, onAdd, onEdit, onDelete, onStart, onStop
             onClick={onStop}
           >
             중지
+          </Button>
+        </span>
+      </Tooltip>
+
+      <Tooltip title="프로세스 강제 종료 (로컬에서만)">
+        <span>
+          <Button
+            startIcon={<PowerSettingsNewIcon />}
+            variant="contained"
+            color="error"
+            disabled={!currentTCP || currentTCP.status !== 'Alive' || !['127.0.0.1', 'localhost'].includes(currentTCP.host)}
+            onClick={onKill}
+            sx={{ ml: 1 }}
+          >
+            Kill
           </Button>
         </span>
       </Tooltip>

--- a/frontend/src/components/TopPanel.jsx
+++ b/frontend/src/components/TopPanel.jsx
@@ -9,7 +9,7 @@ import {
 import TCPServerDialog from './TCPServerDialog';
 import TCPList from './TCPList';
 import TCPActionButtons from './TCPActionButtons';
-import { startTCPServer, stopTCPServer, deleteTCPServer } from '../api/tcpApi';
+import { startTCPServer, stopTCPServer, deleteTCPServer, killTCPServer } from '../api/tcpApi';
 
 const TopPanel = ({ tcpServers, currentTCP, onSelectTCP, onTCPChange, loading }) => {
   const [openDialog, setOpenDialog] = useState(false);
@@ -35,6 +35,18 @@ const TopPanel = ({ tcpServers, currentTCP, onSelectTCP, onTCPChange, loading })
         onTCPChange(); // 서버 목록 갱신
       } catch (error) {
         console.error('TCP 서버 중지 실패:', error);
+      }
+    }
+  };
+
+  // TCP 서버 프로세스 강제 종료
+  const handleKillTCP = async () => {
+    if (currentTCP && (currentTCP.host === '127.0.0.1' || currentTCP.host === 'localhost')) {
+      try {
+        await killTCPServer(currentTCP.id);
+        onTCPChange(); // 서버 목록 갱신
+      } catch (error) {
+        console.error('TCP 프로세스 종료 실패:', error);
       }
     }
   };
@@ -135,6 +147,7 @@ const TopPanel = ({ tcpServers, currentTCP, onSelectTCP, onTCPChange, loading })
           onDelete={handleDeleteTCP}
           onStart={handleStartTCP}
           onStop={handleStopTCP}
+          onKill={handleKillTCP}
         />
       </Box>
 


### PR DESCRIPTION
## Summary
- add backend endpoint to kill active TCP servers on localhost
- expose kill route and UI button with frontend API

## Testing
- `go test ./...`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689540f8370c8330a878663a2a39df46