### PR TITLE
feat: persist packet response history

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Fake-Edge-Server는 REST API를 제공하고 다른 서버와 TCP 통신을 수�
 - SQLite3 데이터베이스 사용 (GORM ORM 사용)
 - 요청 및 TCP 연결 로깅
 - 프론트엔드와의 통합 (React + MUI)
+- 패킷 요청/응답 이력 저장 및 조회
 
 ## 프로젝트 구조
 
@@ -77,6 +78,7 @@ npm run dev
 
 | 날짜 | 내용 | 관련 |
 | --- | --- | --- |
+| 2025-08-08 | 패킷 요청/응답 이력 저장 및 UI 조회 기능 추가 | Frontend/Backend |
 | 2025-08-07 | `UpdateTCPPacketInfo` API로 패킷 정보 수정 기능 추가 | Backend |
 | 2025-08-05 | 패킷 편집 UI 모듈화 및 오류 처리 개선 | Frontend |
 | 2025-08-01 | 체인 행 색상 표시로 가독성 향상 | Frontend |

--- a/backend/database/db.go
+++ b/backend/database/db.go
@@ -21,6 +21,7 @@ func InitDB() (*gorm.DB, error) {
 		&models.TCPConnection{},
 		&models.TCPServer{},
 		&models.TCPPacket{},
+		&models.TCPPacketHistory{},
 	)
 	if err != nil {
 		return nil, err

--- a/backend/handlers/handlers_test.go
+++ b/backend/handlers/handlers_test.go
@@ -27,6 +27,7 @@ func setupTestDB() *gorm.DB {
 		&models.TCPConnection{},
 		&models.TCPServer{},
 		&models.TCPPacket{},
+		&models.TCPPacketHistory{},
 	)
 	if err != nil {
 		panic("마이그레이션 실패: " + err.Error())

--- a/backend/handlers/tcp_packet_history_test.go
+++ b/backend/handlers/tcp_packet_history_test.go
@@ -1,0 +1,87 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/fake-edge-server/models"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+)
+
+func setupPacketRouter(db *gorm.DB) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	handler := NewTCPPacketHandler(db)
+	tc := r.Group("/api/tcp")
+	{
+		tc.POST("/:id/packets/:packet_id/send", handler.SendTCPPacket)
+		tc.GET("/:id/history", handler.GetTCPPacketHistory)
+	}
+	return r
+}
+
+func TestSendTCPPacketStoresHistory(t *testing.T) {
+	db := setupTestDB()
+	router := setupPacketRouter(db)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NoError(t, err)
+	defer ln.Close()
+	go func() {
+		conn, _ := ln.Accept()
+		buf := make([]byte, 1024)
+		n, _ := conn.Read(buf)
+		conn.Write(buf[:n])
+		conn.Close()
+	}()
+
+	addr := ln.Addr().(*net.TCPAddr)
+	server := models.TCPServer{Name: "test", Host: "127.0.0.1", Port: addr.Port}
+	db.Create(&server)
+	packet := models.TCPPacket{TCPServerID: server.ID, Data: models.PacketData{{Offset: 0, Value: 1, Type: models.TypeUint8}}}
+	db.Create(&packet)
+
+	req, _ := http.NewRequest("POST", fmt.Sprintf("/api/tcp/%d/packets/%d/send", server.ID, packet.ID), nil)
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+	assert.Equal(t, http.StatusOK, resp.Code)
+
+	var history models.TCPPacketHistory
+	err = json.Unmarshal(resp.Body.Bytes(), &history)
+	assert.NoError(t, err)
+	assert.Equal(t, "01", history.Request)
+	assert.Equal(t, "01", history.Response)
+
+	var count int64
+	db.Model(&models.TCPPacketHistory{}).Count(&count)
+	assert.Equal(t, int64(1), count)
+}
+
+func TestGetTCPPacketHistory(t *testing.T) {
+	db := setupTestDB()
+	router := setupPacketRouter(db)
+
+	server := models.TCPServer{Name: "test", Host: "127.0.0.1", Port: 1234}
+	db.Create(&server)
+	packet := models.TCPPacket{TCPServerID: server.ID, Data: models.PacketData{{Offset: 0, Value: 1, Type: models.TypeUint8}}}
+	db.Create(&packet)
+	hist := models.TCPPacketHistory{TCPServerID: server.ID, TCPPacketID: packet.ID, Request: "01", Response: "02"}
+	db.Create(&hist)
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/api/tcp/%d/history", server.ID), nil)
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+	assert.Equal(t, http.StatusOK, resp.Code)
+
+	var histories []models.TCPPacketHistory
+	err := json.Unmarshal(resp.Body.Bytes(), &histories)
+	assert.NoError(t, err)
+	assert.Len(t, histories, 1)
+	assert.Equal(t, "01", histories[0].Request)
+}

--- a/backend/models/tcp_packet_history.go
+++ b/backend/models/tcp_packet_history.go
@@ -1,0 +1,18 @@
+package models
+
+import (
+	"gorm.io/gorm"
+	"time"
+)
+
+// TCPPacketHistory stores request/response pairs for sent packets.
+type TCPPacketHistory struct {
+	ID          uint           `json:"id" gorm:"primaryKey"`
+	TCPServerID uint           `json:"tcp_server_id"`
+	TCPPacketID uint           `json:"tcp_packet_id"`
+	Request     string         `json:"request" gorm:"type:text"`
+	Response    string         `json:"response" gorm:"type:text"`
+	CreatedAt   time.Time      `json:"created_at"`
+	UpdatedAt   time.Time      `json:"updated_at"`
+	DeletedAt   gorm.DeletedAt `json:"deleted_at" gorm:"index"`
+}

--- a/backend/routes/routes.go
+++ b/backend/routes/routes.go
@@ -56,6 +56,8 @@ func SetupRoutes(r *gin.Engine, db *gorm.DB) {
 			tc.DELETE("/:id/packets/:id", tcpPacketHandler.DeleteTCPPacket)
 			tc.PUT("/:id/packets/:id", tcpPacketHandler.UpdateTCPPacketInfo)
 			tc.PUT("/:id/packets/:id/data", tcpPacketHandler.UpdateTCPPacketData)
+			tc.POST("/:id/packets/:packet_id/send", tcpPacketHandler.SendTCPPacket)
+			tc.GET("/:id/history", tcpPacketHandler.GetTCPPacketHistory)
 
 		}
 	}

--- a/frontend/src/api/packetApi.js
+++ b/frontend/src/api/packetApi.js
@@ -60,3 +60,8 @@ export async function sendTCPPacket(tcpId, packetId) {
     method: 'POST',
   });
 }
+
+// TCP 요청/응답 이력 조회
+export async function fetchTCPPacketHistory(tcpId) {
+  return await fetchWithErrorHandling(`${API_BASE_URL}/tcp/${tcpId}/history`);
+}

--- a/frontend/src/components/PacketDataTab.jsx
+++ b/frontend/src/components/PacketDataTab.jsx
@@ -24,8 +24,7 @@ import PacketDataTable from './packet/PacketDataTable';
 import PacketFormDialog from './packet/PacketFormDialog';
 import TypeSelectDialog from './packet/TypeSelectDialog';
 import ConfirmUnchainDialog from './packet/ConfirmUnchainDialog';
-import ResponseDialog from './packet/ResponseDialog';
-import ResponseList from './packet/ResponseList';
+import ResponseHistoryPanel from './packet/ResponseHistoryPanel';
 import usePacketData from '../hooks/usePacketData';
 
 const PacketDataTab = ({ currentTCP }) => {
@@ -42,7 +41,6 @@ const PacketDataTab = ({ currentTCP }) => {
     openTypeDialog,
     selectedType,
     alertInfo,
-    responseDialog,
     confirmUnchain,
     msgIdOffset,
     currentMsgId,
@@ -53,7 +51,6 @@ const PacketDataTab = ({ currentTCP }) => {
     setOpenDialog,
     setOpenTypeDialog,
     setSelectedType,
-    setResponseDialog,
     setConfirmUnchain,
     setPacketData,
     loadPackets,
@@ -205,10 +202,7 @@ const PacketDataTab = ({ currentTCP }) => {
         handleDeleteRow={handleDeleteRow}
       />
 
-      <ResponseList
-        responses={responseHistory}
-        onSelect={(res) => setResponseDialog({ open: true, response: res })}
-      />
+      <ResponseHistoryPanel history={responseHistory} />
 
       <PacketFormDialog
         open={openDialog}
@@ -290,11 +284,6 @@ const PacketDataTab = ({ currentTCP }) => {
         </Alert>
       </Snackbar>
 
-      <ResponseDialog
-        open={responseDialog.open}
-        response={responseDialog.response}
-        onClose={() => setResponseDialog({ open: false, response: null })}
-      />
     </Box>
   );
 };

--- a/frontend/src/components/packet/FrameViewer.jsx
+++ b/frontend/src/components/packet/FrameViewer.jsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import { Box, ToggleButtonGroup, ToggleButton, TextField } from '@mui/material';
+import FrameDisplay from './FrameDisplay';
+
+const FrameViewer = ({ data = [] }) => {
+  const [viewType, setViewType] = useState('frame');
+  const handleChange = (_event, next) => {
+    if (next !== null) {
+      setViewType(next);
+    }
+  };
+
+  const jsonValue = JSON.stringify(
+    data.sort((a, b) => a.offset - b.offset),
+    null,
+    2
+  );
+
+  return (
+    <Box>
+      <ToggleButtonGroup
+        value={viewType}
+        exclusive
+        onChange={handleChange}
+        size="small"
+        sx={{ mb: 1 }}
+      >
+        <ToggleButton value="frame">Frame</ToggleButton>
+        <ToggleButton value="json">JSON</ToggleButton>
+      </ToggleButtonGroup>
+      {viewType === 'frame' ? (
+        <FrameDisplay data={data} />
+      ) : (
+        <TextField
+          multiline
+          fullWidth
+          value={jsonValue}
+          InputProps={{ readOnly: true }}
+          minRows={6}
+        />
+      )}
+    </Box>
+  );
+};
+
+export default FrameViewer;
+

--- a/frontend/src/components/packet/ResponseHistoryPanel.jsx
+++ b/frontend/src/components/packet/ResponseHistoryPanel.jsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react';
+import { Box, Button, Typography } from '@mui/material';
+import FrameViewer from './FrameViewer';
+
+const ResponseHistoryPanel = ({ history = [] }) => {
+  const [selected, setSelected] = useState(null);
+
+  return (
+    <Box sx={{ display: 'flex', mt: 2 }}>
+      <Box sx={{ width: '50%', pr: 1 }}>
+        <Typography variant="h6" gutterBottom>
+          요청
+        </Typography>
+        {history.length === 0 ? (
+          <Typography variant="body2" color="text.secondary">
+            요청이 없습니다.
+          </Typography>
+        ) : (
+          history.map((item, idx) => (
+            <Button
+              key={idx}
+              onClick={() => setSelected(item)}
+              sx={{ mr: 1, mb: 1 }}
+              variant="outlined"
+              size="small"
+            >
+              {`${item.packetName}-${item.messageId}`}
+            </Button>
+          ))
+        )}
+        {selected && (
+          <Box sx={{ mt: 2 }}>
+            <Typography variant="subtitle1" gutterBottom>
+              상세보기
+            </Typography>
+            <FrameViewer data={selected.requestData} />
+          </Box>
+        )}
+      </Box>
+      <Box sx={{ width: '50%', pl: 1 }}>
+        <Typography variant="h6" gutterBottom>
+          응답
+        </Typography>
+        {history.length === 0 ? (
+          <Typography variant="body2" color="text.secondary">
+            응답이 없습니다.
+          </Typography>
+        ) : (
+          history.map((item, idx) => (
+            <Button
+              key={idx}
+              onClick={() => setSelected(item)}
+              sx={{ mr: 1, mb: 1, color: item.valid ? 'inherit' : 'error.main' }}
+              variant="outlined"
+              size="small"
+            >
+              {`${item.packetName}-${item.messageId}`}
+            </Button>
+          ))
+        )}
+        {selected && (
+          <Box sx={{ mt: 2 }}>
+            <Typography variant="subtitle1" gutterBottom>
+              상세보기
+            </Typography>
+            <FrameViewer data={selected.responseData} />
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+export default ResponseHistoryPanel;
+


### PR DESCRIPTION
## Summary
- store TCP packet request/response pairs in new TCPPacketHistory model
- expose APIs to send packets and list saved history
- load history in UI and record new responses automatically
- document packet history feature in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689d9f9251d083309e59c9d9b2c588e2